### PR TITLE
Add support for opening SgxFile with cache size

### DIFF
--- a/sgx_tprotected_fs/src/fs.rs
+++ b/sgx_tprotected_fs/src/fs.rs
@@ -57,6 +57,25 @@ unsafe fn rsgx_fopen_auto_key(filename: &CStr, mode: &CStr) -> SysResult<SGX_FIL
     }
 }
 
+unsafe fn rsgx_fopen_ex(
+    filename: &CStr,
+    mode: &CStr,
+    key: Option<&sgx_key_128bit_t>,
+    cache_size: u64,
+) -> SysResult<SGX_FILE> {
+    let file = sgx_fopen_ex(
+        filename.as_ptr(),
+        mode.as_ptr(),
+        key.map_or(core::ptr::null(), |key| key as *const sgx_key_128bit_t),
+        cache_size,
+    );
+    if file.is_null() {
+        Err(errno())
+    } else {
+        Ok(file)
+    }
+}
+
 unsafe fn rsgx_fwrite(stream: SGX_FILE, buf: &[u8]) -> SysResult<usize> {
     if stream.is_null() {
         return Err(libc::EINVAL);
@@ -332,6 +351,61 @@ impl SgxFileStream {
     pub fn open_integrity_only(filename: &CStr, mode: &CStr) -> SysResult<SgxFileStream> {
         unsafe {
             rsgx_fopen_integrity_only(filename, mode).map(|f| SgxFileStream{ stream: f})
+        }
+    }
+
+    ///
+    /// The open function creates or opens a protected file.
+    ///
+    /// # Description
+    ///
+    /// open_ex is expert version of open/open_auto_key which is used if you want to control the internal `cache size`.
+    /// The specified `cache size` must be page (4KB by default) aligned.
+    /// Note that export_auto_key and import_auto_key don't support configuring `cache_size` right now.
+    ///
+    /// # Parameters
+    ///
+    /// **filename**
+    ///
+    /// The name of the file to be created or opened.
+    ///
+    /// **mode**
+    ///
+    /// The file open mode string. Allowed values are any combination of, or, with possible
+    /// and possible (since string functions are currently not sup- ported, is meaningless).
+    ///
+    /// **key**
+    ///
+    /// The encryption key of the file (optional). This key is used as a key derivation key, used for deriving encryption
+    /// keys for the file. If the file is created with open, you should protect this key and provide it as
+    /// input every time the file is opened.
+    ///
+    /// **cache_size**
+    ///
+    /// Internal cache size in byte, which used to cache R/W data in enclave before flush to actual file.
+    /// It must larger than default cache size (192KB), and must be page (4KB by default) aligned.
+    ///
+    /// # Requirements
+    ///
+    /// Header: sgx_tprotected_fs.edl
+    ///
+    /// Library: libsgx_tprotected_fs.a
+    ///
+    /// This API is provided by Occlum's fork of Intel SGX SDK.
+    ///
+    /// # Return value
+    ///
+    /// If the function succeeds, it returns a valid file pointer, which can be used by all the other functions
+    /// in the Protected FS API, otherwise, error code is returned.
+    ///
+    pub fn open_ex(
+        filename: &CStr,
+        mode: &CStr,
+        key: Option<&sgx_key_128bit_t>,
+        cache_size: u64,
+    ) -> SysResult<SgxFileStream> {
+        unsafe {
+            rsgx_fopen_ex(filename, mode, key, cache_size).map(|f| SgxFileStream { stream: f })
         }
     }
 

--- a/sgx_tstd/src/sgxfs.rs
+++ b/sgx_tstd/src/sgxfs.rs
@@ -144,8 +144,16 @@ impl SgxFile {
         OpenOptions::new().read(true).open_ex(path.as_ref(), key)
     }
 
+    pub fn open_with<P: AsRef<Path>>(path: P, key: Option<&sgx_key_128bit_t>, cache_size: Option<u64>) -> io::Result<SgxFile> {
+        OpenOptions::new().read(true).open_with(path.as_ref(), key, cache_size)
+    }
+
     pub fn create_ex<P: AsRef<Path>>(path: P, key: &sgx_key_128bit_t) -> io::Result<SgxFile> {
         OpenOptions::new().write(true).open_ex(path.as_ref(), key)
+    }
+
+    pub fn create_with<P: AsRef<Path>>(path: P, key: Option<&sgx_key_128bit_t>, cache_size: Option<u64>) -> io::Result<SgxFile> {
+        OpenOptions::new().write(true).open_with(path.as_ref(), key, cache_size)
     }
 
     pub fn is_eof(&self) -> bool {
@@ -295,6 +303,10 @@ impl OpenOptions {
         self._open_integrity_only(path.as_ref())
     }
 
+    pub fn open_with<P: AsRef<Path>>(&self, path: P, key: Option<&sgx_key_128bit_t>, cache_size: Option<u64>) -> io::Result<SgxFile> {
+        self._open_with(path.as_ref(), key, cache_size)
+    }
+
     fn _open(&self, path: &Path) -> io::Result<SgxFile> {
         let inner = fs_imp::SgxFile::open(path, &self.0)?;
         Ok(SgxFile { inner })
@@ -308,6 +320,11 @@ impl OpenOptions {
     fn _open_integrity_only(&self, path: &Path) -> io::Result<SgxFile> {
         let inner = fs_imp::SgxFile::open_integrity_only(path, &self.0)?;
         Ok(SgxFile { inner: inner })
+    }
+
+    fn _open_with(&self, path: &Path, key: Option<&sgx_key_128bit_t>, cache_size: Option<u64>) -> io::Result<SgxFile> {
+        let inner = fs_imp::SgxFile::open_with(path, &self.0, key, cache_size)?;
+        Ok(SgxFile { inner })
     }
 }
 

--- a/sgx_types/src/function.rs
+++ b/sgx_types/src/function.rs
@@ -906,6 +906,12 @@ extern "C" {
 
     pub fn sgx_fopen_auto_key(filename: *const c_char, mode: *const c_char) -> SGX_FILE;
     pub fn sgx_fopen_integrity_only(filename: * const c_char, mode: * const c_char) -> SGX_FILE;
+    pub fn sgx_fopen_ex(
+        filename: *const c_char,
+        mode: *const c_char,
+        key: *const sgx_key_128bit_t,
+        cache_size: u64,
+    ) -> SGX_FILE;
     pub fn sgx_fwrite(ptr: * const c_void, size: size_t, count: size_t, stream: SGX_FILE) -> size_t;
     pub fn sgx_fread(ptr: *mut c_void, size: size_t, count: size_t, stream: SGX_FILE) -> size_t;
     pub fn sgx_ftell(stream: SGX_FILE) -> int64_t;


### PR DESCRIPTION
This PR relys on: https://github.com/occlum/linux-sgx/pull/21
Add API `open_with`: open a `SgxFile` with an optioned `cache_size` and an optioned `key`